### PR TITLE
Expand on Exception toString()

### DIFF
--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:figma2flutter/config/args_parser.dart';
 import 'package:figma2flutter/config/options.dart';
+import 'package:figma2flutter/exceptions/process_token_exception.dart';
 import 'package:figma2flutter/exceptions/resolve_token_exception.dart';
 import 'package:figma2flutter/generator.dart';
 import 'package:figma2flutter/models/token_theme.dart';
@@ -19,7 +20,6 @@ import 'package:figma2flutter/transformers/size_transformer.dart';
 import 'package:figma2flutter/transformers/spacing_transformer.dart';
 import 'package:figma2flutter/transformers/typography_transformer.dart';
 import 'package:figma2flutter/utils/sets_and_themes.dart';
-import 'package:path/path.dart';
 
 /// Code for making terminal output foreground red
 const _red = '\x1b[033;0;31m';
@@ -110,6 +110,9 @@ Future<void> main(List<String> arguments) async {
 
     exit(0);
   } on ResolveTokenException catch (e) {
+    _print(e.toString(), _red);
+    rethrow;
+  } on ProcessTokenException catch (e) {
     _print(e.toString(), _red);
     rethrow;
   }

--- a/lib/exceptions/process_token_exception.dart
+++ b/lib/exceptions/process_token_exception.dart
@@ -1,6 +1,11 @@
-class ProcessTokenException {
+class ProcessTokenException implements Exception {
   final String message;
   final Object originalException;
 
   ProcessTokenException(this.message, this.originalException);
+
+  @override
+  String toString() {
+    return 'ProcessTokenException{message: $message, wrapped: $originalException}';
+  }
 }

--- a/lib/exceptions/resolve_token_exception.dart
+++ b/lib/exceptions/resolve_token_exception.dart
@@ -1,4 +1,4 @@
-class ResolveTokenException {
+class ResolveTokenException implements Exception {
   final String message;
 
   ResolveTokenException(this.message);

--- a/test/exceptions/process_token_exception_test.dart
+++ b/test/exceptions/process_token_exception_test.dart
@@ -1,0 +1,17 @@
+import 'package:figma2flutter/exceptions/process_token_exception.dart';
+import 'package:figma2flutter/exceptions/resolve_token_exception.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  test('ProcessTokenException message', () {
+    expect(
+      ProcessTokenException(
+        'hello',
+        ResolveTokenException('some wrapped exception'),
+      ).toString(),
+      equals(
+          'ProcessTokenException{message: hello, wrapped: ResolveTokenException{message: some wrapped exception}}'),
+    );
+  });
+}

--- a/test/exceptions/resolve_token_exception_test.dart
+++ b/test/exceptions/resolve_token_exception_test.dart
@@ -1,0 +1,12 @@
+import 'package:figma2flutter/exceptions/resolve_token_exception.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  test('ProcessTokenException message', () {
+    expect(
+      ResolveTokenException('some wrapped exception').toString(),
+      equals('ResolveTokenException{message: some wrapped exception}'),
+    );
+  });
+}


### PR DESCRIPTION
ProcessTokenException toString() doesn't provide the message when logged.

Noticed this while troubleshooting a problem with the same symptoms (but not cause) as https://github.com/mark-nicepants/figma2flutter/issues/19