### PR TITLE
throw exception instead of null if wrong type in BorderValue

### DIFF
--- a/lib/models/border_value.dart
+++ b/lib/models/border_value.dart
@@ -9,7 +9,12 @@ class BorderValue {
   BorderValue._(this.width, this.style, this.color);
 
   static BorderValue? maybeParse(dynamic value) {
-    if (value is! Map<String, dynamic>) return null;
+    // value is required and must be a map
+    if (value is! Map<String, dynamic>) {
+      throw FormatException(
+        'BorderValue must be a Map and not "$value" of type ${value.runtimeType}',
+      );
+    }
 
     final width =
         DimensionValue.maybeParse(value['width']) ?? DimensionValue.zero;

--- a/lib/models/border_value.dart
+++ b/lib/models/border_value.dart
@@ -9,6 +9,7 @@ class BorderValue {
   BorderValue._(this.width, this.style, this.color);
 
   static BorderValue? maybeParse(dynamic value) {
+    if (value == null) return null;
     // value is required and must be a map
     if (value is! Map<String, dynamic>) {
       throw FormatException(

--- a/test/models/border_value_test.dart
+++ b/test/models/border_value_test.dart
@@ -1,0 +1,31 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:figma2flutter/models/border_value.dart';
+import 'package:figma2flutter/token_parser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final input = '''
+{
+  "radio-button-expandable-expandable-section-border-top": {
+    "value": "none",
+    "type": "border"
+  }
+}
+''';
+
+  // value must be a map for Border and not a string
+  test('Test Broder value invalid value type throws FormatException', () {
+    final parsed = json.decode(input) as Map<String, dynamic>;
+    final parser = TokenParser()..parse(parsed);
+
+    expect(
+      () => parser
+          .resolvedTokens()
+          .map((e) => BorderValue.maybeParse(e.value))
+          .toList(),
+      throwsA(const TypeMatcher<FormatException>()),
+    );
+  });
+}

--- a/test/models/border_value_test.dart
+++ b/test/models/border_value_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:figma2flutter/models/border_value.dart';
 import 'package:figma2flutter/token_parser.dart';


### PR DESCRIPTION
We want to throw if an invalid token definition was used which would be anything other than a map of the 3 attributes of "value". 

1. Border value returns null instead of throwing an exception if the value is anything other than a Map<String, ...>
2. Retains the current behavior of returning null if null was passed in.

This causes a hard to debug later when a null check catches the null. 

This code instead throws a FormatException that will get later wrapped and logged making debugging easier.