### PR TITLE
Implement equality on DimensionValue

### DIFF
--- a/lib/models/dimension_value.dart
+++ b/lib/models/dimension_value.dart
@@ -24,6 +24,18 @@ class DimensionValue {
   String toString() => value.toString();
 
   DimensionValue operator /(num divisor) => DimensionValue(value / divisor);
+  DimensionValue operator +(num addend) => DimensionValue(value + addend);
+  DimensionValue operator -(num difference) =>
+      DimensionValue(value - difference);
+  DimensionValue operator *(num multiplicand) =>
+      DimensionValue(value * multiplicand);
+
+  @override
+  bool operator ==(Object other) =>
+      other is DimensionValue && value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
 }
 
 double _parseNum(String value) {

--- a/test/models/dimension_value_test.dart
+++ b/test/models/dimension_value_test.dart
@@ -53,12 +53,33 @@ void main() {
     );
   });
 
+  test('DimensionValue equals are equal is correct', () {
+    expect(DimensionValue.zero, equals(DimensionValue(0.0)));
+  });
+
+  test('DimensionValue equals are not equal is correct', () {
+    expect(DimensionValue.zero, isNot(equals(10.0)));
+  });
+
   test('DimensionValue zero value is correct', () {
     expect(DimensionValue.zero.value, equals(0.0));
   });
 
-  test('DivisionValue operator / divides value correctly', () {
+  test('DimensionValue operator / divides value correctly', () {
     final value = DimensionValue(12.0) / 2;
     expect(value.value, equals(6.0));
+  });
+
+  test('DimensionValue operator * multiples value correctly', () {
+    final value = DimensionValue(12.0) * 2;
+    expect(value, equals(DimensionValue(24.0)));
+  });
+  test('DimensionValue operator + adds value correctly', () {
+    final value = DimensionValue(12.0) + 2;
+    expect(value, equals(DimensionValue(14.0)));
+  });
+  test('DimensionValue operator - subtracts value correctly', () {
+    final value = DimensionValue(12.0) - 2;
+    expect(value, equals(DimensionValue(10.0)));
   });
 }

--- a/test/models/dimension_value_test.dart
+++ b/test/models/dimension_value_test.dart
@@ -55,10 +55,12 @@ void main() {
 
   test('DimensionValue equals are equal is correct', () {
     expect(DimensionValue.zero, equals(DimensionValue(0.0)));
+    expect(DimensionValue.zero.hashCode, equals(0.0.hashCode));
   });
 
   test('DimensionValue equals are not equal is correct', () {
     expect(DimensionValue.zero, isNot(equals(10.0)));
+    expect(DimensionValue.zero.hashCode, isNot(equals(10.0.hashCode)));
   });
 
   test('DimensionValue zero value is correct', () {


### PR DESCRIPTION
DimensionValues are equal if their values are equal

Comparing doubles can be bad in some languages because of precision but precision errors results in less equality so I didnt' worry about it.