### PR TITLE
Throw exception if theme refers to token set that is not in metadata

### DIFF
--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -77,8 +77,9 @@ Future<void> main(List<String> arguments) async {
     List<TokenTheme> themes;
     if (FileSystemEntity.isDirectorySync(inputFileLocation)) {
       _print(
-          'Loading `\$metadata`, `\$themes` and design token files from $inputFileLocation',
-          _green,);
+        'Loading `\$metadata`, `\$themes` and design token files from $inputFileLocation',
+        _green,
+      );
       _print(''); // New line
       themes = _parseFromFileSet(inputFileLocation);
     } else {

--- a/lib/exceptions/theme_configuration_exception.dart
+++ b/lib/exceptions/theme_configuration_exception.dart
@@ -1,0 +1,10 @@
+class ThemeConfigurationException {
+  final String message;
+
+  ThemeConfigurationException(this.message);
+
+  @override
+  String toString() {
+    return 'ThemeConfigurationException{message: $message}';
+  }
+}

--- a/lib/token_parser.dart
+++ b/lib/token_parser.dart
@@ -1,3 +1,4 @@
+import 'package:figma2flutter/exceptions/theme_configuration_exception.dart';
 import 'package:figma2flutter/models/token.dart';
 import 'package:figma2flutter/models/token_theme.dart';
 import 'package:meta/meta.dart';
@@ -34,6 +35,11 @@ class TokenParser {
       } else {
         tokensForTheme = {};
         for (final set in theme.sets) {
+          if (input[set] == null) {
+            throw (ThemeConfigurationException(
+              'No metadata entry named "$set" expected by theme "${theme.name}"',
+            ));
+          }
           tokensForTheme[set] = input[set] as Map<String, dynamic>;
         }
       }

--- a/test/exceptions/process_token_exception_test.dart
+++ b/test/exceptions/process_token_exception_test.dart
@@ -11,7 +11,8 @@ void main() {
         ResolveTokenException('some wrapped exception'),
       ).toString(),
       equals(
-          'ProcessTokenException{message: hello, wrapped: ResolveTokenException{message: some wrapped exception}}'),
+        'ProcessTokenException{message: hello, wrapped: ResolveTokenException{message: some wrapped exception}}',
+      ),
     );
   });
 }

--- a/test/models/sizing_value_test.dart
+++ b/test/models/sizing_value_test.dart
@@ -1,7 +1,55 @@
+import 'dart:convert';
+
+import 'package:figma2flutter/models/dimension_value.dart';
 import 'package:figma2flutter/models/sizing_value.dart';
+import 'package:figma2flutter/token_parser.dart';
 import 'package:test/test.dart';
 
 void main() {
+  // Future: remote the spacing around the '/' and '*'
+  final input = '''
+{
+  "sizing-base": {
+    "value": "16",
+    "type": "sizing"
+  },
+  "sizing-xxxsmall": {
+    "value": "{sizing-base} / 8",
+    "type": "sizing"
+  },
+  "sizing-small": {
+    "value": "{sizing-base}",
+    "type": "sizing"
+  },
+  "sizing-medium": {
+    "value": "{sizing-base} * 2",
+    "type": "sizing"
+  }
+}
+''';
+  // Note that the parser will return 0.0 if the
+  // math operators are not surrounded by spaces
+  // Remove the space next to '/' or '*' and this will fail
+  test('Test sizing value math expressions', () {
+    final parsed = json.decode(input) as Map<String, dynamic>;
+    final parser = TokenParser()..parse(parsed);
+
+    final parsedValues = parser
+        .resolvedTokens()
+        .map((e) => SizingValue.maybeParse(e.value)?.width)
+        .toList();
+
+    expect(
+      parsedValues,
+      equals([
+        DimensionValue(16.0),
+        DimensionValue(2.0),
+        DimensionValue(16.0),
+        DimensionValue(32.0),
+      ]),
+    );
+  });
+
   test('SizeValue with 2 different values returns valid size', () {
     final size = SizingValue.maybeParse({
       'width': 12.0,

--- a/test/token_parser_test.dart
+++ b/test/token_parser_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:figma2flutter/exceptions/theme_configuration_exception.dart';
+import 'package:figma2flutter/models/token_theme.dart';
+import 'package:figma2flutter/token_parser.dart';
+import 'package:test/test.dart';
+
+final input = '''
+{
+  "dogs":{
+    "corgi": {
+      "value": "#888888",
+      "type": "color"
+    }
+
+  },
+  "cats":{
+    "calico": {
+      "value": "#111111",
+      "type": "color"
+    }
+  }
+}''';
+
+void main() {
+  test(
+    'Themes loads because all metadata sets present',
+    () {
+      List<TokenTheme> themes = [
+        TokenTheme('animals', ['dogs', 'cats']),
+      ];
+      List<String> metadata = ['dogs', 'cats'];
+
+      final parsed = json.decode(input) as Map<String, dynamic>;
+      final parser = TokenParser(metadata, themes)..parse(parsed);
+      expect(parser.resolvedTokens(themeName: 'animals').length, equals(2));
+    },
+  );
+
+  test(
+    'Themes fail loading because of missing metadata',
+    () {
+      List<TokenTheme> themes = [
+        TokenTheme('animals', ['dogs', 'cats', 'cows']),
+      ];
+      List<String> metadata = ['dogs', 'cats'];
+
+      final parsed = json.decode(input) as Map<String, dynamic>;
+      expect(
+        () => TokenParser(metadata, themes)..parse(parsed),
+        throwsA(isA<ThemeConfigurationException>()),
+      );
+    },
+  );
+}

--- a/test/utils/sets_and_themes_test.dart
+++ b/test/utils/sets_and_themes_test.dart
@@ -10,7 +10,8 @@ void main() {
     var loaded = arrangeJsonFilesBySection('test/token_files/input_1');
     expect(loaded, isNotEmpty);
     var expected = json.decode(
-        File('test/token_files/output_1/output.json').readAsStringSync(),);
+      File('test/token_files/output_1/output.json').readAsStringSync(),
+    );
     expect(loaded, equals(expected));
   });
 


### PR DESCRIPTION
Got a `Null can't be assigned to a Map<String, dynamic> ` kind of error if the theme in $theme refers to an entry that is not in $metadata.

Throws an exception that describes the missing entry.