### PR TITLE
Add Argument for Filtering Token Types

### DIFF
--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -56,6 +56,7 @@ Future<void> main(List<String> arguments) async {
   /// Get the input json file and output directory from the parsed arguments
   final inputFileLocation = options.getOption<String>(kInput).value;
   final outputDir = options.getOption<String>(kOutput).value;
+  final shouldOmitCore = options.shouldOmitCore;
 
   // Should remove the defaults because you get weird errors for data you didn't know about
   if (inputFileLocation.isEmpty) {
@@ -92,7 +93,7 @@ Future<void> main(List<String> arguments) async {
     _print('Found ${themes.length} themes, generating code', _green);
 
     /// Process the tokens with all transformers
-    final result = _processTokens(themes);
+    final result = _processTokens(themes, shouldOmitCore);
 
     /// Print the number of tokens each transformer processed to the terminal output
     for (final transformer in result.first.transformers) {
@@ -126,14 +127,14 @@ void _saveOutput(List<TokenTheme> themes, String outputDir) {
 }
 
 /// Process the tokens with all transformers
-List<TokenTheme> _processTokens(List<TokenTheme> themes) {
+List<TokenTheme> _processTokens(List<TokenTheme> themes, bool shouldOmitCore) {
   final processor = Processor(
     themes: themes,
     singleTokenTransformerFactories: singleTokenFactories,
     multiTokenTransformerFactories: multiTokenFactories,
   );
 
-  processor.process();
+  processor.process(shouldOmitCore);
 
   return processor.themes;
 }

--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -117,7 +117,7 @@ List<TokenTheme> _processTokens(
     multiTokenTransformerFactories: multiTokenFactories,
   );
 
-  processor.process(filteredSets);
+  processor.process(filteredSets: filteredSets);
 
   return processor.themes;
 }

--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -9,16 +9,8 @@ import 'package:figma2flutter/generator.dart';
 import 'package:figma2flutter/models/token_theme.dart';
 import 'package:figma2flutter/processor.dart';
 import 'package:figma2flutter/token_parser.dart';
-import 'package:figma2flutter/transformers/border_radius_transformer.dart';
-import 'package:figma2flutter/transformers/border_transformer.dart';
-import 'package:figma2flutter/transformers/box_shadow_transformer.dart';
-import 'package:figma2flutter/transformers/color_transformer.dart';
-import 'package:figma2flutter/transformers/composition_transformer.dart';
-import 'package:figma2flutter/transformers/linear_gradient_transformer.dart';
 import 'package:figma2flutter/transformers/material_color_transformer.dart';
-import 'package:figma2flutter/transformers/size_transformer.dart';
-import 'package:figma2flutter/transformers/spacing_transformer.dart';
-import 'package:figma2flutter/transformers/typography_transformer.dart';
+import 'package:figma2flutter/transformers/single_token_factories.dart';
 import 'package:figma2flutter/utils/sets_and_themes.dart';
 
 /// Code for making terminal output foreground red
@@ -29,20 +21,6 @@ const _green = '\x1b[033;0;32m';
 
 //No Color, reset terminal foreground color
 const _nc = '\x1b[033;0m';
-
-// All transformers that process single tokens should be added here
-// These transformers will be applied to all tokens in the order they are listed
-final singleTokenFactories = <TransformerFactory>[
-  (_) => ColorTransformer(),
-  (_) => SpacingTransformer(),
-  (_) => TypographyTransformer(),
-  (_) => BorderRadiusTransformer(),
-  (_) => CompositionTransformer(),
-  (_) => BoxShadowTransformer(),
-  (_) => BorderTransformer(),
-  (_) => SizeTransformer(),
-  (_) => LinearGradientTransformer(),
-];
 
 // All transformers that process multiple tokens should be added here
 final multiTokenFactories = [
@@ -56,11 +34,9 @@ Future<void> main(List<String> arguments) async {
   /// Get the input json file and output directory from the parsed arguments
   final inputFileLocation = options.getOption<String>(kInput).value;
   final outputDir = options.getOption<String>(kOutput).value;
-  final filteredTokenTypes =
-      options.getOption<String>(kFilteredTokenTypes).value;
-  final List<String> filteredTypes = filteredTokenTypes.isNotEmpty
-      ? filteredTokenTypes.split(',').toList()
-      : [];
+  final filteredTokenSets = options.getOption<String>(kFilteredTokenSets).value;
+  final List<String> filteredSets =
+      filteredTokenSets.isNotEmpty ? filteredTokenSets.split(',').toList() : [];
 
   // Should remove the defaults because you get weird errors for data you didn't know about
   if (inputFileLocation.isEmpty) {
@@ -97,7 +73,7 @@ Future<void> main(List<String> arguments) async {
     _print('Found ${themes.length} themes, generating code', _green);
 
     /// Process the tokens with all transformers
-    final result = _processTokens(themes, filteredTypes);
+    final result = _processTokens(themes, filteredSets);
 
     /// Print the number of tokens each transformer processed to the terminal output
     for (final transformer in result.first.transformers) {
@@ -133,7 +109,7 @@ void _saveOutput(List<TokenTheme> themes, String outputDir) {
 /// Process the tokens with all transformers
 List<TokenTheme> _processTokens(
   List<TokenTheme> themes,
-  List<String> filteredTypes,
+  List<String> filteredSets,
 ) {
   final processor = Processor(
     themes: themes,
@@ -141,7 +117,7 @@ List<TokenTheme> _processTokens(
     multiTokenTransformerFactories: multiTokenFactories,
   );
 
-  processor.process(filteredTypes);
+  processor.process(filteredSets);
 
   return processor.themes;
 }

--- a/bin/figma2flutter.dart
+++ b/bin/figma2flutter.dart
@@ -56,7 +56,11 @@ Future<void> main(List<String> arguments) async {
   /// Get the input json file and output directory from the parsed arguments
   final inputFileLocation = options.getOption<String>(kInput).value;
   final outputDir = options.getOption<String>(kOutput).value;
-  final shouldOmitCore = options.shouldOmitCore;
+  final filteredTokenTypes =
+      options.getOption<String>(kFilteredTokenTypes).value;
+  final List<String> filteredTypes = filteredTokenTypes.isNotEmpty
+      ? filteredTokenTypes.split(',').toList()
+      : [];
 
   // Should remove the defaults because you get weird errors for data you didn't know about
   if (inputFileLocation.isEmpty) {
@@ -93,7 +97,7 @@ Future<void> main(List<String> arguments) async {
     _print('Found ${themes.length} themes, generating code', _green);
 
     /// Process the tokens with all transformers
-    final result = _processTokens(themes, shouldOmitCore);
+    final result = _processTokens(themes, filteredTypes);
 
     /// Print the number of tokens each transformer processed to the terminal output
     for (final transformer in result.first.transformers) {
@@ -127,14 +131,17 @@ void _saveOutput(List<TokenTheme> themes, String outputDir) {
 }
 
 /// Process the tokens with all transformers
-List<TokenTheme> _processTokens(List<TokenTheme> themes, bool shouldOmitCore) {
+List<TokenTheme> _processTokens(
+  List<TokenTheme> themes,
+  List<String> filteredTypes,
+) {
   final processor = Processor(
     themes: themes,
     singleTokenTransformerFactories: singleTokenFactories,
     multiTokenTransformerFactories: multiTokenFactories,
   );
 
-  processor.process(shouldOmitCore);
+  processor.process(filteredTypes);
 
   return processor.themes;
 }

--- a/lib/config/args_parser.dart
+++ b/lib/config/args_parser.dart
@@ -34,28 +34,11 @@ class ArgumentParser extends Parser {
     }
 
     _result.options.forEach(addOption);
-
-    // Handle the new 'shouldOmitCore' flag
-    _argParser.addFlag(
-      kShouldOmitCore,
-      abbr: kShouldOmitCoreAbbr,
-      defaultsTo: false,
-      help: 'Specify to omit "core" tokens.',
-    );
   }
 
   @override
   Future<Options> parse() async {
-    // Parse the arguments to set the options and flags
-    final parsedArgs = _argParser.parse(_arguments);
-
-    // Set the value of the shouldOmitCore flag in the _result
-    _result.shouldOmitCoreFlag = parsedArgs[kShouldOmitCore] as bool;
-
+    _argParser.parse(_arguments);
     return _result;
   }
-
-  // Retrieve the flag value
-  bool get shouldOmitCore =>
-      _argParser.parse(_arguments)[kShouldOmitCore] as bool;
 }

--- a/lib/config/args_parser.dart
+++ b/lib/config/args_parser.dart
@@ -34,11 +34,28 @@ class ArgumentParser extends Parser {
     }
 
     _result.options.forEach(addOption);
+
+    // Handle the new 'shouldOmitCore' flag
+    _argParser.addFlag(
+      kShouldOmitCore,
+      abbr: kShouldOmitCoreAbbr,
+      defaultsTo: false,
+      help: 'Specify to omit "core" tokens.',
+    );
   }
 
   @override
   Future<Options> parse() async {
-    _argParser.parse(_arguments);
+    // Parse the arguments to set the options and flags
+    final parsedArgs = _argParser.parse(_arguments);
+
+    // Set the value of the shouldOmitCore flag in the _result
+    _result.shouldOmitCoreFlag = parsedArgs[kShouldOmitCore] as bool;
+
     return _result;
   }
+
+  // Retrieve the flag value
+  bool get shouldOmitCore =>
+      _argParser.parse(_arguments)[kShouldOmitCore] as bool;
 }

--- a/lib/config/options.dart
+++ b/lib/config/options.dart
@@ -4,20 +4,32 @@ const kInputAbbr = 'i';
 const kOutput = 'output';
 const kOutputAbbr = 'o';
 
-// Flags are optional boolean arguments
-const kShouldOmitCore = 'shouldOmitCore';
-const kShouldOmitCoreAbbr = 'c';
+const kFilteredTokenTypes = 'filtered-token-types';
+const kFilteredTokenTypesAbbr = 'f';
 
+/// Options class to store a single option
 class Option<T> {
+  /// The name of the option
   final String name;
+
+  /// The abbreviation of the option
   final String? abbr;
+
+  /// The help text for the option when using the help flag
   final String help;
+
+  /// The default value of the option
   final T defaultValue;
+
+  /// The parsed value of the option
   T? _value;
 
+  /// Returns the value of the option, if not set, the default value is used
   T get value => _value ?? defaultValue;
 
+  /// Sets the value of the option
   set value(T value) {
+    // * All string options are paths at the moment, sanitize the path
     if (value is String && value.contains('/')) {
       _value = _addRoot(_removeEndSlash(value)) as T;
     } else {
@@ -25,10 +37,15 @@ class Option<T> {
     }
   }
 
+  /// Constructor for the option class
   Option(this.name, this.defaultValue, this.help, [this.abbr]);
 
+  /// Copies this option into a new object
   Option<T> copy() => Option<T>(name, defaultValue, help, abbr);
 
+  /// When merging options we can use the + operator to merge the values
+  /// of the options. If there are more than one option the filled in and
+  /// not the same as the default, the second option will be used.
   Option<T> operator +(Option<T> other) {
     if (name != other.name) throw 'Cannot add to options of different type';
     final newOption = copy();
@@ -42,12 +59,13 @@ class Option<T> {
   }
 }
 
+/// Container that holds all available options for this program
 class Options {
   /// The list of all available options
   List<Option<String>> options = [
     Option<String>(
       kInput,
-      './design/tokens',
+      './design/tokens.json',
       'Specify the directory where the design token json lives.',
       kInputAbbr,
     ),
@@ -57,23 +75,23 @@ class Options {
       'Specify generated output directory.',
       kOutputAbbr,
     ),
+    // Omits tokens by type, I.E. "core, source"
+    Option<String>(
+      kFilteredTokenTypes,
+      '',
+      'Specify token types to filter, separated by commas.',
+      kFilteredTokenTypesAbbr,
+    ),
   ];
 
-  // Separate storage for the shouldOmitCore flag
-  bool _shouldOmitCore = false;
-
-  bool get shouldOmitCore => _shouldOmitCore;
-
-  set shouldOmitCoreFlag(bool value) {
-    _shouldOmitCore = value;
-  }
-
+  /// Returns the option with the given name
   Option<T> getOption<T>(String name) {
     final results = options.where((element) => element.name == name);
     if (results.isEmpty) throw 'Cannot find option with name `$name`';
     return results.first as Option<T>;
   }
 
+  /// Sets the option with the given name to the given value
   void setOption<T>(String name, T? value) {
     if (value != null) {
       getOption<T>(name).value = value;
@@ -84,11 +102,11 @@ class Options {
   String toString() {
     return '''
 Options:
-  $options,
-  shouldOmitCore: $_shouldOmitCore
+  $options
 ''';
   }
 
+  /// When merging options we can use the + operator to merge the values
   Options operator +(Options other) {
     final result = Options();
 
@@ -101,17 +119,18 @@ Options:
 
     options.forEach(mergeOption);
 
-    // Merge shouldOmitCore flag
-    result.shouldOmitCoreFlag = other.shouldOmitCore;
-
     return result;
   }
 }
 
 T _getValue<T>(T first, T second, T defaultValue) {
+  // Same doesnt matter what we return
   if (first == second) return first;
+  // first is default, return second
   if (first == defaultValue) return second;
+  // second is default, return first
   if (second == defaultValue) return first;
+  // second takes precedent when both are not the default value
   return second;
 }
 

--- a/lib/config/options.dart
+++ b/lib/config/options.dart
@@ -4,29 +4,20 @@ const kInputAbbr = 'i';
 const kOutput = 'output';
 const kOutputAbbr = 'o';
 
-/// Options class to store a single option
+// Flags are optional boolean arguments
+const kShouldOmitCore = 'shouldOmitCore';
+const kShouldOmitCoreAbbr = 'c';
+
 class Option<T> {
-  /// The name of the option
   final String name;
-
-  /// The abbreviation of the option
   final String? abbr;
-
-  /// The help text for the option when using the help flag
   final String help;
-
-  /// The default value of the option
   final T defaultValue;
-
-  /// The parsed value of the option
   T? _value;
 
-  /// Returns the value of the option, if not set, the default value is used
   T get value => _value ?? defaultValue;
 
-  /// Sets the value of the option
   set value(T value) {
-    // * All string options are paths at the moment, sanitize the path
     if (value is String && value.contains('/')) {
       _value = _addRoot(_removeEndSlash(value)) as T;
     } else {
@@ -34,15 +25,10 @@ class Option<T> {
     }
   }
 
-  /// Constructor for the option class
   Option(this.name, this.defaultValue, this.help, [this.abbr]);
 
-  /// Copies this option into a new object
   Option<T> copy() => Option<T>(name, defaultValue, help, abbr);
 
-  /// When merging options we can use the + operator to merge the values
-  /// of the options. If there are more than one option the filled in and
-  /// not the same as the default, the second option will be used.
   Option<T> operator +(Option<T> other) {
     if (name != other.name) throw 'Cannot add to options of different type';
     final newOption = copy();
@@ -56,13 +42,12 @@ class Option<T> {
   }
 }
 
-/// Container that holds all available options for this program
 class Options {
   /// The list of all available options
   List<Option<String>> options = [
     Option<String>(
       kInput,
-      './design/tokens.json',
+      './design/tokens',
       'Specify the directory where the design token json lives.',
       kInputAbbr,
     ),
@@ -74,14 +59,21 @@ class Options {
     ),
   ];
 
-  /// Returns the option with the given name
+  // Separate storage for the shouldOmitCore flag
+  bool _shouldOmitCore = false;
+
+  bool get shouldOmitCore => _shouldOmitCore;
+
+  set shouldOmitCoreFlag(bool value) {
+    _shouldOmitCore = value;
+  }
+
   Option<T> getOption<T>(String name) {
     final results = options.where((element) => element.name == name);
     if (results.isEmpty) throw 'Cannot find option with name `$name`';
     return results.first as Option<T>;
   }
 
-  /// Sets the option with the given name to the given value
   void setOption<T>(String name, T? value) {
     if (value != null) {
       getOption<T>(name).value = value;
@@ -92,11 +84,11 @@ class Options {
   String toString() {
     return '''
 Options:
-  $options
+  $options,
+  shouldOmitCore: $_shouldOmitCore
 ''';
   }
 
-  /// When merging options we can use the + operator to merge the values
   Options operator +(Options other) {
     final result = Options();
 
@@ -109,18 +101,17 @@ Options:
 
     options.forEach(mergeOption);
 
+    // Merge shouldOmitCore flag
+    result.shouldOmitCoreFlag = other.shouldOmitCore;
+
     return result;
   }
 }
 
 T _getValue<T>(T first, T second, T defaultValue) {
-  // Same doesnt matter what we return
   if (first == second) return first;
-  // first is default, return second
   if (first == defaultValue) return second;
-  // second is default, return first
   if (second == defaultValue) return first;
-  // second takes precedent when both are not the default value
   return second;
 }
 

--- a/lib/config/options.dart
+++ b/lib/config/options.dart
@@ -4,8 +4,8 @@ const kInputAbbr = 'i';
 const kOutput = 'output';
 const kOutputAbbr = 'o';
 
-const kFilteredTokenTypes = 'filtered-token-types';
-const kFilteredTokenTypesAbbr = 'f';
+const kFilteredTokenSets = 'filtered-token-sets';
+const kFilteredTokenSetsAbbr = 'f';
 
 /// Options class to store a single option
 class Option<T> {
@@ -77,10 +77,10 @@ class Options {
     ),
     // Omits tokens by type, I.E. "core, source"
     Option<String>(
-      kFilteredTokenTypes,
+      kFilteredTokenSets,
       '',
       'Specify token types to filter, separated by commas.',
-      kFilteredTokenTypesAbbr,
+      kFilteredTokenSetsAbbr,
     ),
   ];
 

--- a/lib/config/options.dart
+++ b/lib/config/options.dart
@@ -79,7 +79,7 @@ class Options {
     Option<String>(
       kFilteredTokenSets,
       '',
-      'Specify token types to filter, separated by commas.',
+      'Specify token sets to filter, separated by commas.',
       kFilteredTokenSetsAbbr,
     ),
   ];

--- a/lib/processor.dart
+++ b/lib/processor.dart
@@ -16,10 +16,13 @@ class Processor {
     this.multiTokenTransformerFactories = const [],
   });
 
-  void process() {
+  void process([bool shouldOmitCore = false]) {
     for (final theme in themes) {
       //print('Generating Theme: ${theme.name}');
       final resolved = theme.resolvedTokens;
+      if (shouldOmitCore) {
+        resolved.removeWhere((element) => element.path.startsWith('.core.'));
+      }
 
       final single = _loopProcess(singleTokenTransformerFactories, resolved);
       final multi = _loopProcess(multiTokenTransformerFactories, resolved)

--- a/lib/processor.dart
+++ b/lib/processor.dart
@@ -16,7 +16,7 @@ class Processor {
     this.multiTokenTransformerFactories = const [],
   });
 
-  void process([List<String> filteredSets = const []]) {
+  void process({List<String> filteredSets = const []}) {
     for (final theme in themes) {
       //print('Generating Theme: ${theme.name}');
       final resolved = theme.resolvedTokens;

--- a/lib/processor.dart
+++ b/lib/processor.dart
@@ -16,12 +16,19 @@ class Processor {
     this.multiTokenTransformerFactories = const [],
   });
 
-  void process([bool shouldOmitCore = false]) {
+  void process([List<String> filteredTypes = const []]) {
     for (final theme in themes) {
       //print('Generating Theme: ${theme.name}');
       final resolved = theme.resolvedTokens;
-      if (shouldOmitCore) {
-        resolved.removeWhere((element) => element.path.startsWith('.core.'));
+      if (filteredTypes.isNotEmpty) {
+        resolved.removeWhere((element) {
+          for (final type in filteredTypes) {
+            if (element.path.startsWith('.$type.')) {
+              return true;
+            }
+          }
+          return false;
+        });
       }
 
       final single = _loopProcess(singleTokenTransformerFactories, resolved);

--- a/lib/transformers/single_token_factories.dart
+++ b/lib/transformers/single_token_factories.dart
@@ -1,0 +1,24 @@
+import 'package:figma2flutter/processor.dart';
+import 'package:figma2flutter/transformers/border_radius_transformer.dart';
+import 'package:figma2flutter/transformers/border_transformer.dart';
+import 'package:figma2flutter/transformers/box_shadow_transformer.dart';
+import 'package:figma2flutter/transformers/color_transformer.dart';
+import 'package:figma2flutter/transformers/composition_transformer.dart';
+import 'package:figma2flutter/transformers/linear_gradient_transformer.dart';
+import 'package:figma2flutter/transformers/size_transformer.dart';
+import 'package:figma2flutter/transformers/spacing_transformer.dart';
+import 'package:figma2flutter/transformers/typography_transformer.dart';
+
+// All transformers that process single tokens should be added here
+// These transformers will be applied to all tokens in the order they are listed
+final singleTokenFactories = <TransformerFactory>[
+  (_) => ColorTransformer(),
+  (_) => SpacingTransformer(),
+  (_) => TypographyTransformer(),
+  (_) => BorderRadiusTransformer(),
+  (_) => CompositionTransformer(),
+  (_) => BoxShadowTransformer(),
+  (_) => BorderTransformer(),
+  (_) => SizeTransformer(),
+  (_) => LinearGradientTransformer(),
+];

--- a/test/processor_test.dart
+++ b/test/processor_test.dart
@@ -81,7 +81,7 @@ void main() {
     final processor = Processor(
       themes: parser.themes,
       singleTokenTransformerFactories: singleTokenFactories,
-    )..process([]);
+    )..process(filteredSets: []);
 
     final transformers = processor.themes.first.transformers;
 
@@ -104,6 +104,7 @@ void main() {
       }
     }
   });
+
   test('Test processor filters sets when necessary', () {
     final parsed = json.decode(singleDocInput) as Map<String, dynamic>;
     final setOrder = getSetsFromJson(parsed);
@@ -113,7 +114,7 @@ void main() {
     final processor = Processor(
       themes: parser.themes,
       singleTokenTransformerFactories: singleTokenFactories,
-    )..process(['core', 'spacing']);
+    )..process(filteredSets: ['core', 'spacing']);
 
     final transformers = processor.themes.first.transformers;
     for (final transformer in transformers) {

--- a/test/processor_test.dart
+++ b/test/processor_test.dart
@@ -79,8 +79,8 @@ void main() {
     final parser = TokenParser(setOrder, themes)..parse(parsed);
 
     final processor = Processor(
-      themes: [...parser.themes],
-      singleTokenTransformerFactories: [...singleTokenFactories],
+      themes: parser.themes,
+      singleTokenTransformerFactories: singleTokenFactories,
     )..process([]);
 
     final transformers = processor.themes.first.transformers;
@@ -111,8 +111,8 @@ void main() {
     final parser = TokenParser(setOrder, themes)..parse(parsed);
 
     final processor = Processor(
-      themes: [...parser.themes],
-      singleTokenTransformerFactories: [...singleTokenFactories],
+      themes: parser.themes,
+      singleTokenTransformerFactories: singleTokenFactories,
     )..process(['core', 'spacing']);
 
     final transformers = processor.themes.first.transformers;

--- a/test/processor_test.dart
+++ b/test/processor_test.dart
@@ -5,6 +5,8 @@ import 'package:figma2flutter/exceptions/resolve_token_exception.dart';
 import 'package:figma2flutter/processor.dart';
 import 'package:figma2flutter/token_parser.dart';
 import 'package:figma2flutter/transformers/color_transformer.dart';
+import 'package:figma2flutter/transformers/single_token_factories.dart';
+import 'package:figma2flutter/utils/sets_and_themes.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -69,6 +71,69 @@ void main() {
       throwsA(const TypeMatcher<ResolveTokenException>()),
     );
   });
+
+  test('Test processor does not filter when unnecessary', () {
+    final parsed = json.decode(singleDocInput) as Map<String, dynamic>;
+    final setOrder = getSetsFromJson(parsed);
+    final themes = getThemesFromJson(parsed);
+    final parser = TokenParser(setOrder, themes)..parse(parsed);
+
+    final processor = Processor(
+      themes: [...parser.themes],
+      singleTokenTransformerFactories: [...singleTokenFactories],
+    )..process([]);
+
+    final transformers = processor.themes.first.transformers;
+
+    expect(transformers.length, equals(5));
+    for (final transformer in transformers) {
+      if (transformer.name == 'color') {
+        expect(transformer.lines.length, equals(6));
+      }
+      if (transformer.name == 'spacing') {
+        expect(transformer.lines.length, equals(5));
+      }
+      if (transformer.name == 'textStyle') {
+        expect(transformer.lines.length, equals(3));
+      }
+      if (transformer.name == 'radii') {
+        expect(transformer.lines.length, equals(2));
+      }
+      if (transformer.name == 'size') {
+        expect(transformer.lines.length, equals(4));
+      }
+    }
+  });
+  test('Test processor filters sets when necessary', () {
+    final parsed = json.decode(singleDocInput) as Map<String, dynamic>;
+    final setOrder = getSetsFromJson(parsed);
+    final themes = getThemesFromJson(parsed);
+    final parser = TokenParser(setOrder, themes)..parse(parsed);
+
+    final processor = Processor(
+      themes: [...parser.themes],
+      singleTokenTransformerFactories: [...singleTokenFactories],
+    )..process(['core', 'spacing']);
+
+    final transformers = processor.themes.first.transformers;
+    for (final transformer in transformers) {
+      print(
+        'Found ${transformer.lines.length} ${transformer.name} tokens',
+      );
+    }
+    expect(transformers.length, equals(3));
+    for (final transformer in transformers) {
+      if (transformer.name == 'textStyle') {
+        expect(transformer.lines.length, equals(3));
+      }
+      if (transformer.name == 'radii') {
+        expect(transformer.lines.length, equals(2));
+      }
+      if (transformer.name == 'size') {
+        expect(transformer.lines.length, equals(4));
+      }
+    }
+  });
 }
 
 final input = '''
@@ -106,3 +171,171 @@ final invalidRefColorRef = '''
     "type": "color"
   }
 }''';
+
+final singleDocInput = '''
+{
+  "\$metadata": {
+    "tokenSetOrder": ["global", "core", "semantic-light"]
+  },
+  "\$themes": [
+    {
+      "id": "1a8dc4275d61b3e960452418b36ccaca5044d7f9",
+      "name": "ping",
+      "\$figmaStyleReferences": {
+        "comp.map.radius": "S:c04f87cad480c58b39166b07fa3dab978dd26514",
+        "surface.default": "S:7f742c34b318021ac6b36dd5ea458dffcffdfbc8",
+        "accent.primary.default": "S:cb780648858a45f09d75ed88898f76b4fcc51cc4",
+        "surface.map.gradient": "S:ba5d3b3bd836ce03caf7277380f4e88ae17872c2",
+        "heading.large": "S:ea35d47676ec855b35a76ae0f4a2fb5aba34b2cc",
+        "body.large": "S:1d9426100b4790a47a88e1274882726441f12ca2"
+      },
+      "selectedTokenSets": {
+        "global": "enabled",
+        "core": "source",
+        "semantic-light": "enabled"
+      },
+      "\$figmaCollectionId": "VariableCollectionId:1608:316",
+      "\$figmaModeId": "1608:0",
+      "\$figmaVariableReferences": {
+        "comp.map.radius": "b93a06255d03faf19c79f404da5798d589349a83",
+        "surface.default": "e22c9b3d96eb478d7dc5d4d4825053a8c1b10caf",
+        "accent.primary.default": "b956da767da14a0ea3846bfa54dd5387b445e69a",
+        "surface.map.gradient": "ba5d3b3bd836ce03caf7277380f4e88ae17872c2",
+        "heading.large": "ea35d47676ec855b35a76ae0f4a2fb5aba34b2cc",
+        "body.large": "1d9426100b4790a47a88e1274882726441f12ca2"
+      }
+    }
+  ],
+  "global": {
+    "global": {
+      "spacing": {
+        "0": { "value": 0, "type": "spacing" },
+        "2": { "value": 2, "type": "spacing" },
+        "4": { "value": 4, "type": "spacing" },
+        "6": { "value": 6, "type": "spacing" },
+        "8": { "value": 8, "type": "spacing" }
+      },
+      "lineHeights": {
+        "0": { "value": "100%", "type": "lineHeights" },
+        "16": { "value": 16, "type": "lineHeights" },
+        "18": { "value": 18, "type": "lineHeights" }
+      },
+      "size": {
+        "4": { "value": 4, "type": "sizing" },
+        "8": { "value": 8, "type": "sizing" },
+        "12": { "value": 12, "type": "sizing" },
+        "16": { "value": 16, "type": "sizing" }
+      },
+      "borderRadius": {
+        "0": { "value": 0, "type": "borderRadius" },
+        "8": { "value": 8, "type": "borderRadius" }
+      },
+      "borderWidth": {
+        "0": { "value": 0, "type": "borderWidth" },
+        "1": { "value": 1, "type": "borderWidth" }
+      },
+      "fontSize": {
+        "12": { "value": 12, "type": "fontSizes" },
+        "13": { "value": 13, "type": "fontSizes" }
+      },
+      "letterSpacing": {
+        "0": { "value": 0, "type": "letterSpacing" },
+        "4": { "value": 4, "type": "letterSpacing" }
+      },
+      "opacity": {
+        "0": { "value": "0%", "type": "opacity" },
+        "5": { "value": "5%", "type": "opacity" }
+      }
+    }
+  },
+  "core": {
+    "core": {
+      "color": {
+        "gray": {
+          "5": { "value": "#EAE8E0", "type": "color" },
+          "10": { "value": "#D5D3CD", "type": "color" }
+        },
+        "white": {
+          "0": { "value": "#ffffff00", "type": "color" },
+          "5": { "value": "#ffffff0d", "type": "color" }
+        },
+        "brown": {
+          "5": { "value": "#E0AFA9", "type": "color" }
+        },
+        "indigo": {
+          "40": { "value": "#4B0082", "type": "color" }
+        }
+      },
+      "fontFamilies": {
+        "primary": { "value": "Outfit", "type": "fontFamilies" }
+      },
+      "fontWeight": {
+        "400": { "value": 400, "type": "fontWeight" },
+        "600": { "value": 600, "type": "fontWeight" },
+        "700": { "value": 700, "type": "fontWeight" }
+      }
+    }
+  },
+  "semantic-light": {
+    "comp": {
+      "map": {
+        "radius": {
+          "value": "accent.primary.higher",
+          "type": "color",
+          "\$extensions": {
+            "studio.tokens": {
+              "modify": {
+                "type": "alpha",
+                "value": ".38",
+                "space": "lch"
+              }
+            }
+          }
+        }
+      }
+    },
+    "surface": {
+      "default": {
+        "type": "color",
+        "value": "core.color.brown.5"
+      }
+    },
+    "heading": {
+      "large": {
+        "value": {
+          "fontFamily": "core.fontFamilies.primary",
+          "fontWeight": "core.fontWeight.700",
+          "fontSize": "global.fontSize.32",
+          "lineHeight": "global.lineHeights.40",
+          "letterSpacing": "global.letterSpacing.0"
+        },
+        "type": "typography"
+      }
+    },
+    "label": {
+      "large": {
+        "value": {
+          "fontFamily": "core.fontFamilies.primary",
+          "fontWeight": "core.fontWeight.600",
+          "fontSize": "global.fontSize.18",
+          "lineHeight": "global.lineHeights.24",
+          "letterSpacing": "global.letterSpacing.0"
+        },
+        "type": "typography"
+      }
+    },
+    "body": {
+      "medium": {
+        "value": {
+          "fontFamily": "core.fontFamilies.primary",
+          "fontWeight": "core.fontWeight.400",
+          "fontSize": "global.fontSize.16",
+          "lineHeight": "global.lineHeights.0",
+          "letterSpacing": "global.letterSpacing.0"
+        },
+        "type": "typography"
+      }
+    }
+  }
+}
+''';


### PR DESCRIPTION
Addresses https://github.com/mark-nicepants/figma2flutter/issues/32 

### Pull Request: Add Argument for Filtering Token Types

#### Overview
This pull request introduces a new argument, `filteredTokenTypes`, to exclude specified token types from parsed results:

- **New Argument**: `filteredTokenTypes`
- **Functionality**: Omits specified token types from processing
- **Usage**: `--filtered-token-types=core,source`

#### Files Modified

1. **`bin/figma2flutter.dart`**
   - **Main Function**: 
     - Added `filteredTokenTypes` option
     - Parsed argument into a list of token types
     - Passed `filteredTypes` to `_processTokens`
   - **Token Processing**:
     - Implemented filtering logic in `_processTokens`

2. **`lib/config/options.dart`**
   - **Option Definitions**:
     - Added `filteredTokenTypes` constants and option for configuration

3. **`lib/processor.dart`**
   - **Processor Class**:
     - Updated `process` method to accept `filteredTypes`
     - Added logic to remove tokens based on `filteredTypes` list

#### Example Usage

To run the tool and exclude tokens of types `core` and `source`:
```bash
dart bin/figma2flutter.dart --filtered-token-types=core,source
```

This will filter out tokens with paths starting with `core` or `source`.

#### Conclusion

These updates provide more control over the token processing, enabling users to fine-tune their output. Please review the changes and provide your feedback.


#### Notes: 
I tried skipping reading the "Core" tokens altogether, but other tokens rely on their processing to assign the correct values.