### PR TITLE
account for pascal and camel case font weights

### DIFF
--- a/lib/models/font_weight_value.dart
+++ b/lib/models/font_weight_value.dart
@@ -50,12 +50,19 @@ class FontWeightValue {
 
 final _fontWeightMap = {
   100: ['thin', 'hairline'],
-  200: ['extra-light', 'ultra-light'],
+  200: ['extra-light', 'ultra-light', 'extralight', 'ultralight'],
   300: ['light'],
   400: ['normal', 'regular', 'book'],
   500: ['medium'],
-  600: ['semi-bold', 'demi-bold'],
+  600: ['semi-bold', 'demi-bold', 'semibold', 'demibold'],
   700: ['bold'],
-  800: ['extra-bold', 'ultra-bold'],
-  900: ['black', 'heavy', 'extra-black', 'ultra-black'],
+  800: ['extra-bold', 'ultra-bold', 'extrabold', 'ultrabold'],
+  900: [
+    'black',
+    'heavy',
+    'extra-black',
+    'ultra-black',
+    'extrablack',
+    'ultrablack'
+  ],
 };


### PR DESCRIPTION
Our designer uses PascalCase of font weights so they were getting missed by this matcher.

I considered adding something along the lines of `entry.value.map(val => val.replaceAll('-','').contains(value.toLowerCase()),` too, but didn't think the complexity was worth it for such a small finite set of cases.