### PR TITLE
add negativeNumberPreface

### DIFF
--- a/lib/extensions/string.dart
+++ b/lib/extensions/string.dart
@@ -1,10 +1,17 @@
 import 'package:recase/recase.dart';
 
+const negativeNumberPreface = 'Negative';
+
 extension StringExtension on String {
   String get alphanumeric {
-    // Match all non alphanumeric characters and replace them with a space
-    final pattern = RegExp(r'[^a-zA-Z0-9]');
-    final result = replaceAll(pattern, ' ');
+    // Match '-' only if it is followed by a digit and replace with negativeNumberPreface
+    final patternNegative = RegExp(r'-(?=\d)');
+    // Match all non alphanumeric characters (excluding negativeNumberPreface replacements) and replace them with a space
+    final patternNonAlphanumeric = RegExp(r'[^a-zA-Z0-9]');
+
+    var result = replaceAll(patternNegative, negativeNumberPreface);
+    result = result.replaceAll(patternNonAlphanumeric, ' ');
+
     return result.pascalCase;
   }
 

--- a/test/extensions/strings_test.dart
+++ b/test/extensions/strings_test.dart
@@ -1,6 +1,6 @@
+import 'package:figma2flutter/extensions/string.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
-import 'package:figma2flutter/extensions/string.dart';
 
 void main() {
   test('extension isReference', () {
@@ -30,5 +30,10 @@ void main() {
   test('extension alphanumeric arrows', () {
     final test = '180-deg-↓';
     expect(test.alphanumeric, '180Deg');
+  });
+
+  test('extension alphanumeric negative numbers', () {
+    final test = '-4';
+    expect(test.alphanumeric, 'Negative4');
   });
 }


### PR DESCRIPTION
https://github.com/mark-nicepants/figma2flutter/issues/33

Negative number variable names (I.E. "-4") currently discard the "-", creating breaking duplicate getters. This replaces "-" with "Negative" for negative numbers rather than omitting it.