### PR TITLE
handle additional trailing ;

### DIFF
--- a/lib/models/linear_gradient_value.dart
+++ b/lib/models/linear_gradient_value.dart
@@ -14,8 +14,11 @@ class LinearGradientValue {
     if (value == null || value is! String) return null;
     if (!value.startsWith('linear-gradient')) return null;
 
-    final stripped =
-        value.substring('linear-gradient('.length, value.length - 1).trim();
+    // Remove an extra character if the string ends with a semicolon
+    final trailingCharacters = 1 + (value.endsWith(';') ? 1 : 0);
+    final stripped = value
+        .substring('linear-gradient('.length, value.length - trailingCharacters)
+        .trim();
 
     // Convert rgba colors to hex so we can better parse the string
     final hexColors = _convertRgbColorsToHex(stripped);

--- a/test/transformers/linear_gradient_transformer_test.dart
+++ b/test/transformers/linear_gradient_transformer_test.dart
@@ -19,7 +19,7 @@ final input = '''
     "type": "color"
   },
   "gradient": {
-    "value": "linear-gradient(45deg, #ffffff 0%, #000000 100%)",
+    "value": "linear-gradient(45deg, #ffffff 0%, #000000 100%);",
     "type": "color"
   },
   "gradientMoreStops": {


### PR DESCRIPTION
### PR Description

Fixes Issue: Incorrect Parsing of Linear Gradients with Trailing Semicolons

#### Issue
Some of the `linear-gradient` values in our JSON contain a trailing semicolon. For example:
- Bugged: `"value": "linear-gradient(45deg, #ffffff 0%, #000000 100%);"`
- Working: `"value": "linear-gradient(45deg, #ffffff 0%, #000000 100%)"`

When this occurs, the `DimensionValue._parseNum` function receives `"100%)"`, resulting in it returning `0`.

#### Solution
This PR introduces a change that identifies and removes trailing semicolons (`;`) from `linear-gradient` values, ensuring correct parsing. It maintains the existing stripping of trailing `)` in either case.