### PR TITLE
Fix Color Modifier Handling in Gradients

### DIFF
--- a/lib/models/color_value.dart
+++ b/lib/models/color_value.dart
@@ -67,6 +67,28 @@ class ColorValue {
     return HSL.fromRGB(r, g, b);
   }
 
+  ColorValue applyStudioExtension(dynamic extension) {
+    final modify = extension?['studio.tokens']?['modify'];
+    if (modify == null) return this;
+    final type = modify['type'];
+    final value = double.tryParse(modify['value'] as String? ?? '0');
+    final color = modify['color'] as String?;
+
+    if (value != null && value != 0) {
+      if (type == 'lighten') {
+        return lighten(value / 2);
+      } else if (type == 'darken') {
+        return darken(value / 2);
+      } else if (type == 'alpha') {
+        return alphainate(value);
+      } else if (color != null && type == 'mix' && color.startsWith('#')) {
+        return mix(color, value);
+      }
+    }
+    // Modified was not found
+    return this;
+  }
+
   static ColorValue? maybeParse(dynamic value) {
     if (value == null || value is! String) return null;
 

--- a/lib/models/token.dart
+++ b/lib/models/token.dart
@@ -305,8 +305,8 @@ String? _resolveColorValue(String initialValue, Map<String, Token> tokenMap) {
         'Reference not found for `${match.group(1)}`',
       );
     }
-
-    final color = ColorValue.maybeParse(reference.value);
+    final color = ColorValue.maybeParse(reference.value)
+        ?.applyStudioExtension(reference.extensions);
     if (color == null) {
       return null;
       // throw ResolveTokenException(

--- a/lib/transformers/color_transformer.dart
+++ b/lib/transformers/color_transformer.dart
@@ -34,30 +34,10 @@ class ColorTransformer extends SingleTokenTransformer {
   String transform(Token token) {
     final value = token.value;
 
-    ColorValue? colorValue = ColorValue.maybeParse(value);
+    ColorValue? colorValue =
+        ColorValue.maybeParse(value)?.applyStudioExtension(token.extensions);
     if (colorValue == null) {
       throw Exception('Invalid color value: $value');
-    }
-
-    if (token.hasExtensions) {
-      final modify = token.extensions?['studio.tokens']?['modify'];
-      if (modify != null) {
-        final type = modify['type'];
-        final value = double.tryParse(modify['value'] as String? ?? '0');
-        final color = modify['color'] as String?;
-
-        if (value != null && value != 0) {
-          if (type == 'lighten') {
-            colorValue = colorValue.lighten(value / 2);
-          } else if (type == 'darken') {
-            colorValue = colorValue.darken(value / 2);
-          } else if (type == 'alpha') {
-            colorValue = colorValue.alphainate(value);
-          } else if (color != null && type == 'mix' && color.startsWith('#')) {
-            colorValue = colorValue.mix(color, value);
-          }
-        }
-      }
     }
 
     return colorValue.declaration();

--- a/test/transformers/linear_gradient_transformer_test.dart
+++ b/test/transformers/linear_gradient_transformer_test.dart
@@ -18,8 +18,25 @@ final input = '''
     "value": "#ffffff",
     "type": "color"
   },
+  "transparent": {
+    "value": "#ffffff",
+    "type": "color",
+    "\$extensions": {
+      "studio.tokens": {
+        "modify": {
+          "type": "alpha",
+          "value": ".38",
+          "space": "lch"
+        }
+      }
+    }
+  },
   "gradient": {
     "value": "linear-gradient(45deg, #ffffff 0%, #000000 100%)",
+    "type": "color"
+  },
+  "gradientWithAlphaModifier": {
+    "value": "linear-gradient(45deg, {white} 0%, {transparent} 100%)",
     "type": "color"
   },
   "gradientMoreStops": {
@@ -36,6 +53,14 @@ final output = '''
 @override
   LinearGradient get gradient => const LinearGradient(
   colors: [Color(0xFFFFFFFF), Color(0xFF000000),],
+  stops: [0.0, 1.0],
+  begin: Alignment.bottomCenter,
+  end: Alignment.topCenter,
+  transform: GradientRotation(0.785),
+);
+@override
+  LinearGradient get gradientWithAlphaModifier => const LinearGradient(
+  colors: [Color(0xFFFFFFFF), Color(0x61FFFFFF),],
   stops: [0.0, 1.0],
   begin: Alignment.bottomCenter,
   end: Alignment.topCenter,
@@ -63,7 +88,7 @@ void main() {
     final parsed = json.decode(input) as Map<String, dynamic>;
     final parser = TokenParser()..parse(parsed);
 
-    expect(parser.resolvedTokens().length, equals(6));
+    expect(parser.resolvedTokens().length, equals(8));
 
     final transformer = LinearGradientTransformer();
     parser.resolvedTokens().forEach(transformer.process);


### PR DESCRIPTION
### Pull Request Description: Fix Color Modifier Handling in Gradients

#### Issue
References to colors in gradients currently drop the color modifier, leading to incorrect colors in gradients.

#### Solution
Abstract the modifier logic used in the `ColorTransformer` to a method within the `ColorValue` class. This allows the logic to be shared with the token parser reference resolver, ensuring consistent application of color modifications when that is supplied (as in the Gradient flow).

#### Changes

1. **New Method in `ColorValue` Class**:
   - Introduced an `applyStudioExtension` method using the pre-existing logic nested in ColorTransfomer.transform.

2. **Integration into Token Parsing**:
   - Updated `_resolveColorValue` and `ColorTransformer` to utilize the new method for applying extensions.
   ```dart
   // Updated _resolveColorValue
   final color = ColorValue.maybeParse(reference.value)
                            ?.applyStudioExtension(reference.extensions);
   ```

3. **Test Enhancements**:
   - Added test coverage for alpha modifications to a gradient color.

#### Note
There is a potential improvement by always supplying a nullable extension when parsing `ColorValues`. However, further investigation of other usage scenarios is recommended before making this change more broadly.