### PR TITLE
restore names when negative sign is in between words

### DIFF
--- a/lib/extensions/string.dart
+++ b/lib/extensions/string.dart
@@ -5,7 +5,7 @@ const negativeNumberPreface = 'Negative';
 extension StringExtension on String {
   String get alphanumeric {
     // Match '-' only if it is followed by a digit and replace with negativeNumberPreface
-    final patternNegative = RegExp(r'-(?=\d)');
+    final patternNegative = RegExp(r'^(-)(?=\d)');
     // Match all non alphanumeric characters (excluding negativeNumberPreface replacements) and replace them with a space
     final patternNonAlphanumeric = RegExp(r'[^a-zA-Z0-9]');
 

--- a/test/extensions/strings_test.dart
+++ b/test/extensions/strings_test.dart
@@ -35,5 +35,14 @@ void main() {
   test('extension alphanumeric negative numbers', () {
     final test = '-4';
     expect(test.alphanumeric, 'Negative4');
+    final test2 = '-4-grey';
+    expect(test2.alphanumeric, 'Negative4Grey');
+  });
+
+  test('extension alphanumeric with minus sign', () {
+    final test = 'White-4';
+    expect(test.alphanumeric, 'White4');
+    final test2 = 'White-4-dog';
+    expect(test2.alphanumeric, 'White4Dog');
   });
 }

--- a/test/extensions/strings_test.dart
+++ b/test/extensions/strings_test.dart
@@ -37,6 +37,8 @@ void main() {
     expect(test.alphanumeric, 'Negative4');
     final test2 = '-4-grey';
     expect(test2.alphanumeric, 'Negative4Grey');
+    final test3 = '--4';
+    expect(test3.alphanumeric, '4');
   });
 
   test('extension alphanumeric with minus sign', () {

--- a/test/extensions/strings_test.dart
+++ b/test/extensions/strings_test.dart
@@ -39,6 +39,8 @@ void main() {
     expect(test2.alphanumeric, 'Negative4Grey');
     final test3 = '--4';
     expect(test3.alphanumeric, '4');
+    final test4 = '-grey-4';
+    expect(test4.alphanumeric, 'Grey4');
   });
 
   test('extension alphanumeric with minus sign', () {


### PR DESCRIPTION
Negative signs inside a label are removed.  This was previous behavior that was regressed

https://github.com/mark-nicepants/figma2flutter/issues/41